### PR TITLE
Update AdGuardHome.yaml.template: 更新 anti-AD 地址

### DIFF
--- a/luci-app-adguardhome/root/etc/AdGuardHome/AdGuardHome.yaml.template
+++ b/luci-app-adguardhome/root/etc/AdGuardHome/AdGuardHome.yaml.template
@@ -98,7 +98,7 @@ filters:
   name: AdGuard Simplified Domain Names filter
   id: 1
 - enabled: false
-  url: https://cdn.jsdelivr.net/gh/privacy-protection-tools/anti-AD/anti-ad-easylist.txt
+  url: https://cdn.jsdelivr.net/gh/privacy-protection-tools/anti-AD@master/anti-ad-easylist.txt
   name: anti-AD(Adblock+neohosts+yhosts+cjxlist+adhlist)
   id: 1577113202
 - enabled: true


### PR DESCRIPTION
[anti-AD](https://github.com/privacy-protection-tools/anti-AD) 功能更新才会打新的 tag，现在最新的 tag 都是 1 年前的文件了，需要加上 `@master` 解析到最新的文件。

[文档](https://anti-ad.net/)给的地址是 <https://anti-ad.net/easylist.txt>，应该是 GH-Pages，也可以考虑。